### PR TITLE
Set the new block buttons on window load

### DIFF
--- a/supertable/resources/js/MatrixInputAlt.js
+++ b/supertable/resources/js/MatrixInputAlt.js
@@ -43,7 +43,7 @@ Craft.MatrixInputAlt = Garnish.Base.extend(
 		this.$addBlockBtnGroupBtns = this.$addBlockBtnGroup.children('.btn');
 		this.$addBlockMenuBtn = this.$addBlockBtnContainer.children('.menubtn');
 
-		this.setNewBlockBtn();
+		$(window).on('load', $.proxy(this.setNewBlockBtn, this));
 
 		this.blockTypesByHandle = {};
 


### PR DESCRIPTION
If a SuperTable contains a Matrix, and this Matrix has to many fields there's a JS bug where the `setNewBlockBtn` function gets called. This results in a UI Bug where the Fields aren't grouped in an "Add a Block" button. 
Before:
![screen shot](https://cloud.githubusercontent.com/assets/879612/9808779/d1955498-5862-11e5-8609-3441b53aecb9.png)
After:
![screen shot 2](https://cloud.githubusercontent.com/assets/879612/9808832/36862a3a-5863-11e5-8d78-ddcbe1d0468e.png)

