### PR TITLE
Added a Variable to allow finding elements related through a SuperTable field.

### DIFF
--- a/supertable/variables/SuperTableVariable.php
+++ b/supertable/variables/SuperTableVariable.php
@@ -4,6 +4,105 @@ namespace Craft;
 class SuperTableVariable
 {
 
+    /**
+     * Expands the defualt relationship behaviour to include Super Table
+     * fields so that the user can filter by those too.
+     *
+     * For example:
+     *
+     * ```twig
+     * {% set reverseRelatedElements = craft.supertable.getRelatedElements({
+     *   relatedTo : {
+     *     targetElement: entry,
+     *     field: 'superTableFieldHandle.columnHandle'
+     *   },
+     *   elementType : 'SomePlugin_Element',
+     *   criteria : {
+     *     id : 'not 123',
+     *     section : 'someSection'
+     *   }
+     * })
+     * ```
+     *
+     * @method getRelatedElements
+     * @param  array                $params  Should contain 'relatedTo' but can also optionally
+     *                                       include 'elementType' and 'criteria'
+     * @return ElementCriteriaModel
+     */
+    public function getRelatedElements($params = null)
+    {
+
+      // Parse out the field handles
+      $superTableFieldHandle = explode('.', $params['relatedTo']['field'])[0];
+      $superTableBlockFieldHandle = explode('.', $params['relatedTo']['field'])[1];
+
+      // For saftey fail early if that didn't work
+      if (!$superTableFieldHandle || !$superTableFieldHandle)
+      {
+        return false;
+      }
+
+      // Get the Super Table field and associated block type
+      $superTableField = craft()->fields->getFieldByHandle($superTableFieldHandle);
+      $superTableBlockType = craft()->superTable->getBlockTypesByFieldId($superTableField->id)[0];
+
+      // Loop the fields on the block type and save the first one that matches our handle
+      $fieldId = false;
+      foreach ($superTableBlockType->getFields() as $field)
+      {
+        if ($field->handle === $superTableBlockFieldHandle )
+        {
+          $fieldId = $field->id;
+          break;
+        }
+      }
+
+      // Check we got something and update the relatedTo criteria for our next elements call
+      if ($fieldId)
+      {
+        $params['relatedTo']['field'] = $fieldId;
+      }
+      else
+      {
+        return false;
+      }
+
+      // Get the Super Table Blocks that are related to that field
+      $superTableBlocks = craft()->elements->getCriteria('SuperTable_Block', array(
+        'relatedTo' => $params['relatedTo']
+      ));
+
+      // Loop over the returned Super Table Blocks and save their owner ids
+      $elementIds = array();
+      foreach ($superTableBlocks as $superTableBlock)
+      {
+        $elementIds[] = $superTableBlock->ownerId;
+      }
+
+      // Defualt to getting Entry elements but let the user override
+      $elementType = ElementType::Entry;
+      if (isset($params['elementType']))
+      {
+        $elementType = $params['elementType'];
+      }
+
+      // Start our final criteria with the element ids we just got
+      $finalCriteria = array(
+        'id' => $elementIds
+      );
+
+      // Check if the user gave us another criteria model and merge that in
+      if (isset($params['criteria']))
+      {
+        $finalCriteria = array_merge($finalCriteria, $params['criteria']);
+      }
+
+      // Return our final element criteria
+      return craft()->elements->getCriteria($elementType, $finalCriteria);
+
+    }
+
+
     //
     // Having a Matrix-SuperTable-Matrix layout will cause issues becase it will try to apply the namespace for the top-level
     // Matrix field, which means inner-Matrix fields will not work properly. Very hacky, but we need to replicate the Matrix


### PR DESCRIPTION
This solves the same problem that is described in the Going Through Matrix section of the [relations documentation](https://buildwithcraft.com/docs/relations).

Params:
- `relatedTo` - required in full.
- `elementType` - optional element type, if not given it will default to Entries.
- `criteria` - optional element criteria model for the final elements API call.

An example:

```twig
{% set reverseRelatedElements = craft.supertable.getRelatedElements({
 relatedTo : {
   targetElement: entry,
   field: 'superTableFieldHandle.columnHandle'
 },
 elementType : 'SomePlugin_Element',
 criteria : {
   id : 'not 123',
   section : 'someSection'
 }
})
```