### PR TITLE
Fix the table width

### DIFF
--- a/supertable/resources/css/SuperTableInput.css
+++ b/supertable/resources/css/SuperTableInput.css
@@ -1,5 +1,6 @@
 table.editable.superTable {
     margin-top: 10px;
+    table-layout: fixed;
 }
 
 table.editable.superTable tbody tr td {


### PR DESCRIPTION
The table width is not really 100% and the margin left and right get added to it because the `table-layout: fixed` is not set via css. This breaks the button dropdown javascript logic

![bildschirmfoto 2015-12-08 um 13 49 52](https://cloud.githubusercontent.com/assets/879612/11656032/b1582792-9db2-11e5-842e-bfafd3bd00c0.png)
