### PR TITLE
Adds missing translate filter to table input

### DIFF
--- a/supertable/templates/tableInput.html
+++ b/supertable/templates/tableInput.html
@@ -32,7 +32,7 @@
 
                             <th scope="col" class="col-header" {% if width is defined and width %}style="width: {{ width }}"{% endif %}>
                                 <span class="heading-text {% if field.required %}required{% endif %}">
-                                    {{ field.name }} {% if field.instructions %}<span class="info">{{ field.instructions }}</span>{% endif %}
+                                    {{ field.name|t }} {% if field.instructions %}<span class="info">{{ field.instructions|t }}</span>{% endif %}
                                 </span>
                             </th>
                         {% endfor %}
@@ -51,7 +51,7 @@
                         {% set blocks = [blocks] %}
                     {% endif %}
                 {% endif %}
-                
+
                 {% for block in blocks %}
                     {% set blockId = block.id %}
 
@@ -64,7 +64,7 @@
                         <td class="hidden">
                             <input type="hidden" name="{{ name }}[{{ blockId }}][type]" value="{{ block.getType() }}">
                         </td>
-                        
+
                         {% include "supertable/fields" with {
                             namespace: name~'['~blockId~'][fields]',
                             element: block,
@@ -87,5 +87,3 @@
         <div class="btn add icon" {% if settings.staticField %}style="display: none;"{% endif %}>{{ settings.selectionLabel | default("Add a row") | t }}</div>
     </div>
 </div>
-
-


### PR DESCRIPTION
The table headers for the table input are missing the `|t` filter, which is a bit annoying (I use namespacing for the actual values, in order to have a fully translated CP.