### PR TITLE
Fix errors caused by SuperTableBlockElement.eagerLoadingMap()

### DIFF
--- a/src/elements/SuperTableBlockElement.php
+++ b/src/elements/SuperTableBlockElement.php
@@ -80,7 +80,7 @@ class SuperTableBlockElement extends Element
     {
         // Get the block type
         $supertableFieldId = $sourceElements[0]->fieldId;
-        $blockTypes = ArrayHelper::index(SuperTable::$plugin->service->getBlockTypesByFieldId($supertableFieldId));
+        $blockTypes = SuperTable::$plugin->service->getBlockTypesByFieldId($supertableFieldId);
 
         if (!isset($blockTypes[0])) {
             // Not a valid block type handle (assuming all $sourceElements are blocks from the same SuperTable field)
@@ -94,7 +94,7 @@ class SuperTableBlockElement extends Element
         $originalFieldContext = $contentService->fieldContext;
         $contentService->fieldContext = 'superTableBlockType:' . $blockType->id;
 
-        $map = parent::eagerLoadingMap($sourceElements, $fieldHandle);
+        $map = parent::eagerLoadingMap($sourceElements, $handle);
 
         $contentService->fieldContext = $originalFieldContext;
 


### PR DESCRIPTION
Invalid use of ArrayHelper.index generates the following error:
```
Internal Server Error
Too few arguments to function yii\helpers\BaseArrayHelper::index(), 1 passed in vendor/verbb/super-table/src/elements/SuperTableBlockElement.php on line 83 and at least 2 expected
```
$fieldHandle is not declared (it appears to be a typo).