### PR TITLE
WIP: Sprout import support

### DIFF
--- a/src/SuperTable.php
+++ b/src/SuperTable.php
@@ -57,6 +57,11 @@ class SuperTable extends Plugin
             });
         }
 
+        if (class_exists(Importers::class)) {
+            Event::on(Importers::class, Importers::EVENT_REGISTER_IMPORTER_TYPES, function (RegisterComponentTypesEvent $event) {
+                $event->types[] = 'verbb\supertable\integrations\sproutimport\importers\fields\SuperTableImporter';
+            });
+        }
         // Setup Variables class (for backwards compatibility)
         Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function(Event $event) {
             $variable = $event->sender;

--- a/src/SuperTable.php
+++ b/src/SuperTable.php
@@ -16,6 +16,8 @@ use craft\web\twig\variables\CraftVariable;
 use NerdsAndCompany\Schematic\Schematic;
 use NerdsAndCompany\Schematic\Events\ConverterEvent;
 
+use barrelstrength\sproutbase\app\import\services\Importers;
+
 use yii\base\Event;
 
 class SuperTable extends Plugin
@@ -41,12 +43,12 @@ class SuperTable extends Plugin
             'matrixService' => SuperTableMatrixService::class,
         ]);
 
-        Event::on(Fields::className(), Fields::EVENT_REGISTER_FIELD_TYPES, function(RegisterComponentTypesEvent $event) {
+        Event::on(Fields::className(), Fields::EVENT_REGISTER_FIELD_TYPES, function (RegisterComponentTypesEvent $event) {
             $event->types[] = SuperTableField::class;
         });
 
         if (class_exists(Schematic::class)) {
-            Event::on(Schematic::class, Schematic::EVENT_RESOLVE_CONVERTER, function(ConverterEvent $event) {
+            Event::on(Schematic::class, Schematic::EVENT_RESOLVE_CONVERTER, function (ConverterEvent $event) {
                 if ($event->modelClass == SuperTableField::class) {
                     $event->converterClass = 'verbb\supertable\integrations\schematic\converters\fields\SuperTableSchematic';
                 }
@@ -62,8 +64,9 @@ class SuperTable extends Plugin
                 $event->types[] = 'verbb\supertable\integrations\sproutimport\importers\fields\SuperTableImporter';
             });
         }
+
         // Setup Variables class (for backwards compatibility)
-        Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function(Event $event) {
+        Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function (Event $event) {
             $variable = $event->sender;
             $variable->set('superTable', SuperTableVariable::class);
         });

--- a/src/integrations/sproutimport/importers/fields/SuperTableImporter.php
+++ b/src/integrations/sproutimport/importers/fields/SuperTableImporter.php
@@ -1,0 +1,53 @@
+<?php
+namespace verbb\supertable\integrations\sproutimport\importers\fields;
+
+use Craft;
+use verbb\supertable\SuperTable;
+use barrelstrength\sproutbase\app\import\base\FieldImporter;
+use barrelstrength\sproutimport\SproutImport;
+use verbb\supertable\fields\SuperTableField;
+
+class SuperTableImporter extends FieldImporter
+{
+    /**
+     * @return string
+     */
+    public function getModelName()
+    {
+        return SuperTableField::class;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMockData()
+    {
+        $fieldId = $this->model->id;
+        $blocks = SuperTable::$plugin->service->getBlockTypesByFieldId($fieldId);
+
+        $values = [];
+
+        if (!empty($blocks)) {
+            $count = 1;
+
+            foreach ($blocks as $block) {
+                $key = 'new'.$count;
+
+                $values[$key] = [
+                    'type' => $block->id,
+                    'enabled' => 1
+                ];
+
+                $fieldLayoutId = $block->fieldLayoutId;
+
+                $fieldLayouts = Craft::$app->getFields()->getFieldsByLayoutId($fieldLayoutId);
+
+                $values[$key]['fields'] = SproutImport::$app->fieldImporter->getFieldsWithMockData($fieldLayouts);
+
+                $count++;
+            }
+        }
+
+        return $values;
+    }
+}


### PR DESCRIPTION
Opening this as WIP.

Currently it works great with Sprout Import's seed functionality, however when importing, users are still required to provide the block ID, which should be able to be inferred, as SuperTable fields are 1:1 with `supertableblocktypes`.

I suspect we'll need some help from @BenParizek on an approach.