### PR TITLE
Fixes for schematic integration with a supertable nested in a matrix field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.8 -
+
+### Fixed
+
+- Fixed nested Super Table (in Matrix) fields Support for [Schematic](https://github.com/nerds-and-company/schematic)
+
 ## 2.0.7 - 2018-05-08
 
 ### Added

--- a/src/models/SuperTableBlockTypeModel.php
+++ b/src/models/SuperTableBlockTypeModel.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace verbb\supertable\models;
 
+use Craft;
 use verbb\supertable\elements\SuperTableBlockElement;
 
 use craft\base\FieldInterface;
@@ -32,6 +34,11 @@ class SuperTableBlockTypeModel extends Model
      */
     public $hasFieldErrors = false;
 
+    /**
+     * @var string
+     */
+    private $handle;
+
     // Public Methods
     // =========================================================================
 
@@ -56,6 +63,36 @@ class SuperTableBlockTypeModel extends Model
         return [
             [['id', 'fieldId'], 'number', 'integerOnly' => true],
         ];
+    }
+
+    /**
+     * Set fake handle.
+     *
+     * @param string
+     */
+    public function setHandle($handle)
+    {
+        $this->handle = $handle;
+    }
+
+    /**
+     * Fake handle for easier integrations.
+     *
+     * @return string
+     */
+    public function getHandle()
+    {
+        if (!isset($this->handle) && $this->fieldId) {
+            $field = Craft::$app->fields->getFieldById($this->fieldId);
+            foreach ($field->getBlockTypes() as $index => $blockType) {
+                if ($blockType->id == $this->id) {
+                    $this->handle = $field->handle.'-'.$index;
+                    break;
+                }
+            }
+        }
+
+        return $this->handle;
     }
 
     /**


### PR DESCRIPTION
When the supertable was nested in a matrix field the save handlers were not called.
to handle this case a lot of the logic has been moved to the setAttributes methods.

Aside from this I've added a fake handle to the blocktype model to match for existing block types when importing.