### PR TITLE
Craft 3.0.23 compatibility

### DIFF
--- a/src/services/SuperTableMatrixService.php
+++ b/src/services/SuperTableMatrixService.php
@@ -119,10 +119,28 @@ class SuperTableMatrixService extends Component
             }
         }
 
+        $blockTypes = [];
+        $blockTypeFields = [];
+        $totalNewBlockTypes = 0;
+
+        foreach ($matrixField->getBlockTypes() as $blockType) {
+            $blockTypeId = (string)($blockType->id ?? 'new' . ++$totalNewBlockTypes);
+            $blockTypes[$blockTypeId] = $blockType;
+
+            $blockTypeFields[$blockTypeId] = [];
+            $totalNewFields = 0;
+            foreach ($blockType->getFields() as $field) {
+                $fieldId = (string)($field->id ?? 'new' . ++$totalNewFields);
+                $blockTypeFields[$blockTypeId][$fieldId] = $field;
+            }
+        }
+
         return Craft::$app->getView()->renderTemplate('_components/fieldtypes/Matrix/settings',
             [
                 'matrixField' => $matrixField,
-                'fieldTypes' => $fieldTypeOptions
+                'fieldTypes' => $fieldTypeOptions,
+                'blockTypes' => $blockTypes,
+                'blockTypeFields' => $blockTypeFields,
             ]);
     }
 


### PR DESCRIPTION
Craft 3.0.23’s `_components/fieldtypes/Matrix/settings.html` template will expect these `blockTypes` and `blockTypeFields` variables to be set, and I noticed that Super Table is rendering that template as well. (See craftcms/cms@eeac5b670583167704f86196f1b9323aa19aeb5b)

This change can be made without breaking < 3.0.23 compatibility; older versions of `_components/fieldtypes/Matrix/settings.html` will just ignore the extra variables.