### PR TITLE
Fixed Dashboard error

### DIFF
--- a/src/fields/SuperTableField.php
+++ b/src/fields/SuperTableField.php
@@ -505,7 +505,7 @@ class SuperTableField extends Field implements EagerLoadingFieldInterface
                 $block = new SuperTableBlockElement();
                 $block->fieldId = $this->id;
                 $block->typeId = $blockType->id;
-                $block->siteId = $element->siteId ?? null;
+                $block->siteId = $element->siteId ?? Craft::$app->getSites()->getCurrentSite()->id;
 
                 // Set each field to be fresh for auto-generated or static rows
                 foreach ($blockType->getFieldLayout()->getFields() as $field) {

--- a/src/fields/SuperTableField.php
+++ b/src/fields/SuperTableField.php
@@ -505,7 +505,7 @@ class SuperTableField extends Field implements EagerLoadingFieldInterface
                 $block = new SuperTableBlockElement();
                 $block->fieldId = $this->id;
                 $block->typeId = $blockType->id;
-                $block->siteId = $element->siteId;
+                $block->siteId = $element->siteId ?? null;
 
                 // Set each field to be fresh for auto-generated or static rows
                 foreach ($blockType->getFieldLayout()->getFields() as $field) {


### PR DESCRIPTION
If a Quick Post widget contained a Super Table field that had only 1 block type and Min Rows was set, then a PHP error would occur on the Dashboard when attempting to render the field HTML.

(Matrix had the exact same bug, and this is the same fix.)