### PR TITLE
Fixes #127 error.

### DIFF
--- a/src/migrations/m180219_000000_sites.php
+++ b/src/migrations/m180219_000000_sites.php
@@ -50,15 +50,15 @@ class m180219_000000_sites extends Migration
 
         foreach ($this->db->getSchema()->getTableNames() as $tableName) {
             if (StringHelper::startsWith($tableName, $superTableTablePrefix)) {
-                // Rename column
-                if ($this->db->columnExists($tableName, 'locale__siteId')) {
-                    $this->renameColumn($tableName, 'locale__siteId', 'siteId');
-                }
-
                 // There's actually an issue here in the MigrationHelper::dropAllIndexesOnTable class, not using the current migration
                 // as context to find existing indexes. This is important, because the indexes have changed from their current names
                 $this->dropAllForeignKeysOnTable($tableName);
                 $this->dropAllIndexesOnTable($tableName);
+
+                // Rename column
+                if ($this->db->columnExists($tableName, 'locale__siteId')) {
+                    $this->renameColumn($tableName, 'locale__siteId', 'siteId');
+                }
 
                 // Add them back (like creating a new Matrix would)
                 $this->createIndex(null, $tableName, ['elementId', 'siteId'], true);


### PR DESCRIPTION
Drop indexes before renaming instead of after. Otherwise this causes errors on mariadb.