### PR TITLE
Update m180210_000000_migrate_content_tables.php

### DIFF
--- a/src/migrations/m180210_000000_migrate_content_tables.php
+++ b/src/migrations/m180210_000000_migrate_content_tables.php
@@ -38,7 +38,7 @@ class m180210_000000_migrate_content_tables extends Migration
 
                 echo $oldContentTable . " -> " . $newContentTable . "\n\n";
 
-                if (Craft::$app->db->tableExists($oldContentTable)) {
+                if (Craft::$app->db->tableExists($oldContentTable) && !Craft::$app->db->tableExists($newContentTable)) {
                     $this->renameTable($oldContentTable, $newContentTable);
                 }
             }


### PR DESCRIPTION
I kept getting a collision where a table had already been renamed, and the upgrade would fail. This small change fixed it and seemed generally benign.