### PR TITLE
Adds missing use statement for Locale

### DIFF
--- a/src/fields/SuperTableField.php
+++ b/src/fields/SuperTableField.php
@@ -30,6 +30,7 @@ use craft\helpers\ElementHelper;
 use craft\helpers\Gql as GqlHelper;
 use craft\helpers\Json;
 use craft\helpers\StringHelper;
+use craft\i18n\Locale;
 use craft\queue\jobs\ApplyNewPropagationMethod;
 use craft\queue\jobs\ResaveElements;
 use craft\services\Elements;


### PR DESCRIPTION
Fixes an error when translating the description if the propagation method is set to PROPAGATION_METHOD_LANGUAGE