### PR TITLE
Add BlockType to superTableMatrix, superTableRow, tr.

### DIFF
--- a/src/templates/matrix/input.html
+++ b/src/templates/matrix/input.html
@@ -15,7 +15,7 @@
                 {% do view.registerDeltaName(baseInputName) %}
             {% endif %}
 
-            <div class="superTableMatrix matrixblock {{ staticField ? 'static' }}" data-id="{{ blockId }}"{% if block.collapsed %} data-collapsed{% endif %}>
+            <div class="superTableMatrix matrixblock {{ staticField ? 'static' }}" data-id="{{ blockId }}" data-type="{{ id }}"{% if block.collapsed %} data-collapsed{% endif %}>
                 {{ hiddenInput("#{name}[sortOrder][]", blockId) }}
                 {{ hiddenInput("#{baseInputName}[type]", block.getType().id) }}
 

--- a/src/templates/row/input.html
+++ b/src/templates/row/input.html
@@ -15,7 +15,7 @@
                 {% do view.registerDeltaName(baseInputName) %}
             {% endif %}
 
-            <div class="superTableRow" data-id="{{ blockId }}">
+            <div class="superTableRow" data-id="{{ blockId }}" data-type="{{ id }}">
                 {{ hiddenInput("#{name}[sortOrder][]", blockId) }}
                 {{ hiddenInput("#{baseInputName}[type]", block.getType().id) }}
 

--- a/src/templates/table/input.html
+++ b/src/templates/table/input.html
@@ -51,7 +51,7 @@
                         {% do view.registerDeltaName(baseInputName) %}
                     {% endif %}
 
-                    <tr data-id="{{ blockId }}">
+                    <tr data-id="{{ blockId }}" data-type="{{ id }}">
                         <td class="hidden">
                             {{ hiddenInput("#{name}[sortOrder][]", blockId) }}
                             {{ hiddenInput("#{baseInputName}[type]", block.getType().id) }}


### PR DESCRIPTION
Currently, it is difficult to attach Custom CSS to SuperTable blocks. With this change, this is much easier.

Why custom CSS in the control panel?
When a content builder becomes complex or relatively large, then in my eyes it makes a lot of sense to give the content blocks a colored border. Thus you get a better overview of where a block starts and where it ends. 