### PR TITLE
Fix propagation when entry propagation method is "custom"

### DIFF
--- a/src/services/SuperTableService.php
+++ b/src/services/SuperTableService.php
@@ -810,6 +810,7 @@ class SuperTableService extends Component
                     /** @var Element[] $localizedOwners */
                     $localizedOwners = $owner::find()
                         ->drafts($owner->getIsDraft())
+                        ->provisionalDrafts($owner->isProvisionalDraft)
                         ->revisions($owner->getIsRevision())
                         ->id($owner->id)
                         ->siteId($otherSiteIds)
@@ -839,6 +840,7 @@ class SuperTableService extends Component
                             !empty($sharedPreexistingOtherSiteIds = array_intersect($preexistingOtherSiteIds, $sourceSupportedSiteIds)) &&
                             $preexistingLocalizedOwner = $owner::find()
                                 ->drafts($owner->getIsDraft())
+                                ->provisionalDrafts($owner->isProvisionalDraft)
                                 ->revisions($owner->getIsRevision())
                                 ->id($owner->id)
                                 ->siteId($sharedPreexistingOtherSiteIds)
@@ -921,6 +923,7 @@ class SuperTableService extends Component
                 /** @var Element[] $otherSources */
                 $otherSources = $target::find()
                     ->drafts($source->getIsDraft())
+                    ->provisionalDrafts($source->isProvisionalDraft)
                     ->revisions($source->getIsRevision())
                     ->id($source->id)
                     ->siteId($otherSiteIds)
@@ -930,6 +933,7 @@ class SuperTableService extends Component
                 /** @var Element[] $otherTargets */
                 $otherTargets = $target::find()
                     ->drafts($target->getIsDraft())
+                    ->provisionalDrafts($target->isProvisionalDraft)
                     ->revisions($target->getIsRevision())
                     ->id($target->id)
                     ->siteId($otherSiteIds)


### PR DESCRIPTION
This PR are is related to how Super Table propagates when the Entry is set to "Let each entry choose which sites it should be saved to.

![image](https://user-images.githubusercontent.com/77567/135022851-58c9f1ab-edd5-4231-9857-57b24792f10b.png)

In my case, my Super Table field has _it's_ propagation method set to "Save blocks to other sites with the same language".

![image](https://user-images.githubusercontent.com/77567/135022949-8ef463c1-0b9d-4da5-8c1e-464871e0ca8d.png)

Before this fix, when I went to "Add a site" to an entry, the content in my Super Table field was not propagating to the _new_ site that I selected.

![image](https://user-images.githubusercontent.com/77567/135023042-45312d6a-c930-4842-9319-77d912581739.png)

My expectation is that Super Table would act like other Craft fields where the new site's entry would have all the values of the source entry at creation.  I have a weak understanding of many of the systems at play here, but in my testing this change resolved the issue I was experiencing.  [This SO post by @brandonkelly](https://craftcms.stackexchange.com/a/38046/10495) gives a little context on the `provisionalDraft` property if you are new to it as well.

### Versions

- Craft: 3.7.13
- Super Table: 2.6.8