### PR TITLE
Fix elements overflowing grid column bounds in Row Layout

### DIFF
--- a/src/resources/src/scss/_input.scss
+++ b/src/resources/src/scss/_input.scss
@@ -242,10 +242,10 @@
 
 .superTable-layout-row-new-body {
     display: grid;
-    grid-template-columns: auto 1fr 46px;
+    grid-template-columns: auto minmax(0, 1fr) 46px;
 
     &.static-field {
-        grid-template-columns: auto 1fr 0;
+        grid-template-columns: auto minmax(0, 1fr) 0;
     }
 }
 


### PR DESCRIPTION
Fixes a content overflow issue when using a matrix with many block types inside of a Super Table using Row Layout. (Likely the same issue as #396)

### Steps to Reproduce
1. Install Super Table >= 2.4.7 and Craft >= 3.7
2. Create a matrix field with several block types (or block types with longer names)
3. Create a Super Table field using Row Layout and include the matrix field
4. Size the viewport narrow enough that the matrix block type buttons at the end of the field would be wider than the row layout's main column

### Cause
[Super Table 2.4.7](https://github.com/verbb/super-table/issues/342#issuecomment-607754696) adjusted the Row Layout styling to use CSS Grid with automatic (`1fr`) sizing for the main column of field content. When the intrinsic sizing of the elements inside that column are wider than the available space, they may overflow their container (a [“grid blowout”](https://css-tricks.com/preventing-a-grid-blowout/)). 

The vast majority of field types use relative sizing and work just fine. However, when nesting a matrix field with many block types, the Garnish JS that powers the button bar to add additional blocks relies on the parent container sizing to recognize when the button bar should collapse into a single "+ Add a block" dropdown, versus remaining as individual horizontal flex items. Because the flex items don't naturally wrap, they trigger the grid sizing issue overflow their grid column bounds. Since the column then appears as wide as all of the flex items, the Garnish JS to determine if the parent is wide enough thinks the container is plenty wide to leave them expanded.

### Fix Details
To work around this, we can adjust the grid definition to set a minimum width on the main content grid column so that its flexibility is constrained. With the grid column constrained, the Garnish JS will behave as expected and collapse the buttons into a single dropdown.