### PR TITLE
Find and fix tables with missing indexes

### DIFF
--- a/src/controllers/PluginController.php
+++ b/src/controllers/PluginController.php
@@ -229,6 +229,16 @@ class PluginController extends Controller
             }
         }
 
+        // Identify tables that are missing the correct index from a missed/failed migration
+        foreach (Craft::$app->db->schema->getTableNames() as $tableName) {
+            if (strstr($tableName, 'stc_')) {
+                $correctIndexExists = MigrationHelper::doesIndexExist($tableName, ['elementId', 'siteId'], true, Craft::$app->db);
+                if (!$correctIndexExists) {
+                    echo "    > {$tableName} is missing the correct unique index on elementId and siteId...\n";
+                }
+            }
+        }
+
         // Find all nested Super Tables - find their parent field and update
         $superTableFields = (new Query())
             ->select(['*'])


### PR DESCRIPTION
This code identifies and fixes tables that have had failed migrations leaving them with the wrong unique key indexes. Right now I have had to run the fix-content-tables twice to get everything there, but it's so close. For me, it resolved all of the table issues I'd seen before. Should fix https://github.com/verbb/super-table/issues/409