### PR TITLE
Fixes verbb/super-table#444

### DIFF
--- a/src/templates/row/fields.html
+++ b/src/templates/row/fields.html
@@ -21,7 +21,7 @@
                 {{ field.name | t('site') }}
 
                 {% if field.instructions %}
-                    <span class="info">{{ field.instructions | t('site') | md | raw | e }}</span>
+                    <span class="info">{{ field.instructions | t('site') | e | md }}</span>
                 {% endif %}
 
                 {% if translatable %}

--- a/src/templates/table/input.html
+++ b/src/templates/table/input.html
@@ -24,7 +24,7 @@
 
                             <th scope="col" class="col-header" {% if width %}style="width: {{ width }}"{% endif %}>
                                 <span class="heading-text {% if field.required %}required{% endif %}">
-                                    {{ field.name | t('site') }} {% if field.instructions %}<span class="info">{{ field.instructions | t('site') | md | raw | e }}</span>{% endif %} {% if translatable %}<span class="extralight" data-icon="language" title="{{ translationDescription ?? 'This field is translatable.' | t('app') }}"></span>{% endif %}
+                                    {{ field.name | t('site') }} {% if field.instructions %}<span class="info">{{ field.instructions | t('site') | e | md }}</span>{% endif %} {% if translatable %}<span class="extralight" data-icon="language" title="{{ translationDescription ?? 'This field is translatable.' | t('app') }}"></span>{% endif %}
                                 </span>
                             </th>
                         {% endfor %}


### PR DESCRIPTION
This PR fixes the issue described in #444, by escaping field instructions before running them through the markdown filter, instead of after.

Additionally, the redundant `raw` filter is removed since [the core `md` filter has the `'is_safe' => ['html']` option set](https://github.com/craftcms/cms/blob/develop/src/web/twig/Extension.php#L251), and will always return unescaped HTML.