### PR TITLE
Craft 4.0 fixes

### DIFF
--- a/src/gql/resolvers/elements/SuperTableBlock.php
+++ b/src/gql/resolvers/elements/SuperTableBlock.php
@@ -11,7 +11,7 @@ class SuperTableBlock extends ElementResolver
     /**
      * @inheritdoc
      */
-    public static function prepareQuery(mixed $source, array $arguments, $fieldName = null): ElementQuery
+    public static function prepareQuery(mixed $source, array $arguments, $fieldName = null): mixed
     {
         // If this is the beginning of a resolver chain, start fresh
         if ($source === null) {

--- a/src/gql/types/generators/SuperTableBlockType.php
+++ b/src/gql/types/generators/SuperTableBlockType.php
@@ -6,7 +6,6 @@ use verbb\supertable\elements\SuperTableBlockElement;
 use verbb\supertable\fields\SuperTableField;
 use verbb\supertable\gql\interfaces\elements\SuperTableBlock as SuperTableBlockInterface;
 use verbb\supertable\gql\types\elements\SuperTableBlock;
-use verbb\supertable\models\SuperTableBlockType;
 
 use Craft;
 use craft\gql\base\Generator;


### PR DESCRIPTION
- Fix return type of prepareQuery to be mixed
- Useless import of SuperTableBlockType clashes with the generator class being defined.

Note: Setting the type to mixed is an umbrella that could be perceived as a dirty fix, so eventuallly, there could be a rework to avoid returning different types, but that's all up to you. 👍 

Fixes #462