### PR TITLE
Make sure sort order is updated when block ownership is duplicated

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -869,14 +869,14 @@ class Service extends Component
                     } else {
                         $newBlockId = $block->getCanonicalId();
                     }
+                } elseif ($block->primaryOwnerId === $target->id) {
+                    // Only the block ownership was duplicated, so just update its sort order for the target element
+                    Db::update('{{%supertableblocks_owners}}', [
+                        'sortOrder' => $block->sortOrder,
+                    ], ['blockId' => $block->id, 'ownerId' => $target->id], updateTimestamp: false);
+                    $newBlockId = $block->id;
                 } else {
-                    // If the block’s primary owner is equal to the target element ID, no need to do anything
-                    if ($block->primaryOwnerId !== $target->id) {
-                        /** @var SuperTableBlockElement $newBlock */
-                        $newBlockId = $elementsService->duplicateElement($block, $newAttributes)->id;
-                    } else {
-                        $newBlockId = $block->id;
-                    }
+                    $newBlockId = $elementsService->duplicateElement($block, $newAttributes)->id;
                 }
 
                 $newBlockIds[] = $newBlockId;


### PR DESCRIPTION
This PR will resolve #468, where changes in sort order for pre-existing blocks do not carry over when provisional drafts are applied.

The fix is lifted mostly verbatim from https://github.com/craftcms/cms/blob/6d1e2614ca2c2f55f797cd4d5dc3299a5c4dfcdc/src/services/Matrix.php#L863.