### PR TITLE
Fix block revision creation bug

### DIFF
--- a/src/services/Service.php
+++ b/src/services/Service.php
@@ -1005,10 +1005,13 @@ SQL
      */
     public function createRevisionBlocks(SuperTableField $field, ElementInterface $canonical, ElementInterface $revision): void
     {
+        // Only fetch blocks in the sites the owner element supports
+        $siteIds = ArrayHelper::getColumn(ElementHelper::supportedSitesForElement($canonical), 'siteId');
+
         $blocks = SuperTableBlockElement::find()
             ->ownerId($canonical->id)
             ->fieldId($field->id)
-            ->siteId('*')
+            ->siteId($siteIds)
             ->unique()
             ->status(null)
             ->all();


### PR DESCRIPTION
Copies the fix in craftcms/cms@8712697.

Fixes a block revision creation bug for entries that had been deleted for a site.