### PR TITLE
Fixes Github issue 488

### DIFF
--- a/src/migrations/m220308_100000_owners_table.php
+++ b/src/migrations/m220308_100000_owners_table.php
@@ -33,8 +33,8 @@ class m220308_100000_owners_table extends Migration
         $this->update($blocksTable, ['sortOrder' => '1'], ['sortOrder' => null]);
 
         $this->execute(<<<SQL
-INSERT INTO $ownersTable ([[blockId]], [[ownerId]], [[sortOrder]]) 
-SELECT [[id]], [[ownerId]], [[sortOrder]] 
+INSERT IGNORE INTO $ownersTable ([[blockId]], [[ownerId]], [[sortOrder]])
+SELECT [[id]], [[ownerId]], [[sortOrder]]
 FROM $blocksTable
 SQL
         );


### PR DESCRIPTION
The `m220308_100000_owners_table` migration fails following an upgrade from Craft `3.x` -> `4.x`

Related issue: #488 

Further investigation revealed this to be the result of a [foreign key constraint error](https://github.com/verbb/super-table/issues/488#issuecomment-1284441161).