### PR TITLE
Fix m220308_100000_owners_table.php for postgres

### DIFF
--- a/src/migrations/m220308_100000_owners_table.php
+++ b/src/migrations/m220308_100000_owners_table.php
@@ -32,12 +32,23 @@ class m220308_100000_owners_table extends Migration
         // Fix any null sortOrders. It can happen!
         $this->update($blocksTable, ['sortOrder' => '1'], ['sortOrder' => null]);
 
-        $this->execute(<<<SQL
+        if ($this->db->getIsPgsql()) {
+            $this->execute(<<<SQL
+INSERT INTO $ownersTable ([[blockId]], [[ownerId]], [[sortOrder]])
+SELECT [[id]], [[ownerId]], [[sortOrder]]
+FROM $blocksTable
+ON CONFLICT DO NOTHING
+SQL
+            );
+        } else {
+            $this->execute(<<<SQL
 INSERT IGNORE INTO $ownersTable ([[blockId]], [[ownerId]], [[sortOrder]])
 SELECT [[id]], [[ownerId]], [[sortOrder]]
 FROM $blocksTable
 SQL
-        );
+            );
+        }
+
 
         // drop sortOrder
         $this->dropIndexIfExists('{{%supertableblocks}}', ['sortOrder'], false);


### PR DESCRIPTION
postgres does not support the "INSERT IGNORE INTO" syntax.

Note: I did not test this exact code as commited, as I had already applied a "hacked" migration and have no backup directly before it -  so please double check. 

Here's the error message I received previously when upgrading a postgres based installation to version 3.0.5 of super table:

```
*** applying m220308_100000_owners_table
    > dropping {{%supertableblocks_owners}} if it exists ... done (time: 0.001s)
    > create table {{%supertableblocks_owners}} ... done (time: 0.005s)
    > add foreign key craft_fk_enlcjmbefrmguxxecuenrwmymwyhfnqhwfuj: {{%supertableblocks_owners}} (blockId) references {{%supertableblocks}} (id) ... done (time: 0.003s)
    > add foreign key craft_fk_kfbpgzobqawigdniqatxkxrgldjrjhuagmcs: {{%supertableblocks_owners}} (ownerId) references {{%elements}} (id) ... done (time: 0.002s)
    > update in {{%supertableblocks}} ... done (time: 0.021s)
    > execute SQL: INSERT IGNORE INTO {{%supertableblocks_owners}} ([[blockId]], [[ownerId]], [[sortOrder]])
SELECT [[id]], [[ownerId]], [[sortOrder]]
FROM {{%supertableblocks}} ...Exception: SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "IGNORE"
LINE 1: INSERT IGNORE INTO "craft_supertableblocks_owners" ("blockId...
               ^
The SQL being executed was: INSERT IGNORE INTO "craft_supertableblocks_owners" ("blockId", "ownerId", "sortOrder")
SELECT "id", "ownerId", "sortOrder"
```