### PR TITLE
Fix new static field error when min/max row settings set

### DIFF
--- a/src/fields/SuperTableField.php
+++ b/src/fields/SuperTableField.php
@@ -864,7 +864,10 @@ class SuperTableField extends Field implements EagerLoadingFieldInterface, GqlIn
 
         if (
             $element->getScenario() === Element::SCENARIO_LIVE &&
-            ($this->minRows || $this->maxRows)
+            ($this->minRows || $this->maxRows) &&
+            // Don't check static fields, since unedited static fields on new entries, or that were newly added to an
+            // existing entry's field layout, that had minRows/maxRows set would cause the array validator to fail
+            !$this->staticField
         ) {
             $arrayValidator = new ArrayValidator([
                 'min' => $this->minRows ?: null,


### PR DESCRIPTION
This fixes #512 by skipping the `ArrayValidator` usage in `SuperTableField::validateBlocks()` if the Super Table field is set to be static. The error causing #512 seems to be caused by the `$blocks` array being empty when saving a new entry, if a static Super Table field wasn't edited. I'm not sure if this would be the preferred solution, though, e.g. you might prefer to unset the field's `minRows`/`maxRows` settings if the field is set to be static.

On a related note, it might also be worth hiding the row-related field settings when the field is static, since they're not really relevant in that case; I'll open that as a separate PR in a minute, in case one or the other isn't a preferred solution.