### PR TITLE
Propagate delete for site to nested elements

### DIFF
--- a/src/console/controllers/utils/PruneOrphanedSuperTableBlocksController.php
+++ b/src/console/controllers/utils/PruneOrphanedSuperTableBlocksController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace verbb\supertable\console\controllers\utils;
+
+use Craft;
+use craft\console\Controller;
+use craft\db\Query;
+use craft\db\Table;
+use craft\helpers\Console;
+use verbb\supertable\elements\SuperTableBlockElement;
+use yii\console\ExitCode;
+
+class PruneOrphanedSuperTableBlocksController extends Controller
+{
+    /**
+     * Prunes orphaned super table blocks for each site.
+     *
+     * @return int
+     */
+    public function actionIndex(): int
+    {
+        if (!Craft::$app->getIsMultiSite()) {
+            $this->stdout("This command should only be run for multi-site installs.\n", Console::FG_YELLOW);
+            return ExitCode::OK;
+        }
+
+        $elementsService = Craft::$app->getElements();
+
+        // get all sites
+        $sites = Craft::$app->getSites()->getAllSites();
+
+        // for each site get all super table blocks with owner that doesn't exist for this site
+        foreach ($sites as $site) {
+            $this->stdout(sprintf('Finding orphaned super table blocks for site "%s" ... ', $site->getName()));
+
+            $esSubQuery = (new Query())
+                ->from(['es' => Table::ELEMENTS_SITES])
+                ->where([
+                    'and',
+                    '[[es.elementId]] = [[supertableblocks.primaryOwnerId]]',
+                    ['es.siteId' => $site->id],
+                ]);
+
+            $supertableBlocks = SuperTableBlockElement::find()
+                ->status(null)
+                ->siteId($site->id)
+                ->where(['not exists', $esSubQuery])
+                ->all();
+
+            if (empty($supertableBlocks)) {
+                $this->stdout("none found\n", Console::FG_GREEN);
+                continue;
+            }
+
+            $this->stdout(sprintf("%s found\n", count($supertableBlocks)), Console::FG_RED);
+
+            // delete the ones we found
+            foreach ($supertableBlocks as $block) {
+                $this->do(sprintf('Deleting block %s in %s', $block->id, $site->getName()), function() use ($block, $elementsService) {
+                    $elementsService->deleteElementForSite($block);
+                });
+            }
+        }
+
+        $this->stdout("\nFinished pruning orphaned Super Table blocks.\n", Console::FG_GREEN);
+        return ExitCode::OK;
+    }
+}

--- a/src/fields/SuperTableField.php
+++ b/src/fields/SuperTableField.php
@@ -1176,6 +1176,25 @@ class SuperTableField extends Field implements EagerLoadingFieldInterface, GqlIn
     /**
      * @inheritdoc
      */
+    public function beforeElementDeleteForSite(ElementInterface $element): bool
+    {
+        $elementsService = Craft::$app->getElements();
+        $supertableBlocks = SuperTableBlockElement::find()
+            ->primaryOwnerId($element->id)
+            ->status(null)
+            ->siteId($element->siteId)
+            ->all();
+
+        foreach ($supertableBlocks as $supertableBlock) {
+            $elementsService->deleteElementForSite($supertableBlock);
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function afterElementRestore(ElementInterface $element): void
     {
         // Also restore any Super Table blocks for this element


### PR DESCRIPTION
Replicates https://github.com/craftcms/cms/pull/14154 for Super Table.

- Adds `beforeElementDeleteForSite` method to the `SuperTableField`.
- Adds `super-table/utils/prune-orphaned-super-table-blocks` command, which loops through each of the sites and, for each site, looks for Super Table blocks which exist for that site but whose owner doesn’t. Resulting blocks are passed to `services\Elements::deleteElementsForSite()` so they can be deleted for that site.