### PR TITLE
Fix Craft 5 content migration

### DIFF
--- a/src/fields/SuperTableField.php
+++ b/src/fields/SuperTableField.php
@@ -20,6 +20,11 @@ class SuperTableField extends Matrix
         return '@verbb/supertable/icon-mask.svg';
     }
 
+    /**
+     * @var string Content table name
+     * @deeprecated in 4.0.0
+     */
+    public string $contentTable = '';
 
     // Public Methods
     // =========================================================================
@@ -41,6 +46,10 @@ class SuperTableField extends Matrix
         if (array_key_exists('maxRows', $config)) {
             $config['maxEntries'] = ArrayHelper::remove($config, 'maxRows');
         }
+
+        // We need to keep the contentTable value around, as it's needed for the v4 (Craft 5) upgrade.
+        // (Explicitly set it here because Matrix::__construct() just unsets it.)
+        $this->contentTable = ArrayHelper::remove($config, 'contentTable') ?? '';
 
         parent::__construct($config);
     }


### PR DESCRIPTION
Without the `contentTable` property, Super Table fields nested within Matrix fields will lose their `contentTable` config values as their configs are recreated [here](https://github.com/craftcms/cms/blob/64edeff0d3d6cb3a2650cae758af5d67c1c3e2f6/src/migrations/m230617_070415_entrify_matrix_blocks.php#L129-L132). Without that, the `craft5` migration won’t know where to fetch the field’s content from.