### PR TITLE
Preserve static field behaviour

### DIFF
--- a/src/migrations/m240115_000000_craft5.php
+++ b/src/migrations/m240115_000000_craft5.php
@@ -194,9 +194,17 @@ class m240115_000000_craft5 extends BaseContentRefactorMigration
             }
 
             // update the field config
-            $fieldConfig['settings']['maxEntries'] = ArrayHelper::remove($fieldConfig['settings'], 'maxBlocks');
-            $fieldConfig['settings']['minEntries'] = ArrayHelper::remove($fieldConfig['settings'], 'minBlocks');
             $fieldConfig['settings']['entryTypes'] = array_map(fn(EntryType $entryType) => $entryType->uid, $fieldEntryTypes);
+
+            // If this field is a static field, override and set min and max rows to 1 to preserve this behaviour in Craft 5
+            if (isset($fieldConfig['settings']['staticField']) && $fieldConfig['settings']['staticField']) {
+                $fieldConfig['settings']['minRows'] = 1;
+                $fieldConfig['settings']['maxRows'] = 1;
+            } else {
+                $fieldConfig['settings']['maxEntries'] = ArrayHelper::remove($fieldConfig['settings'], 'maxBlocks');
+                $fieldConfig['settings']['minEntries'] = ArrayHelper::remove($fieldConfig['settings'], 'minBlocks');
+            }
+
             $fieldConfig['settings']['viewMode'] = 'blocks';
 
             unset($fieldConfig['settings']['contentTable']);


### PR DESCRIPTION
We have run into a problem migrating our sites to Craft 5 with SuperTable fields that were configured to be static. For example, in Craft 4 with SuperTable, we had:

![image](https://github.com/user-attachments/assets/5b55eb8f-3c13-49a2-a084-b6556f75f5c3)

When we migrated this to a Craft 5 matrix, the fact that this was a static field was lost entirely:

![image](https://github.com/user-attachments/assets/b2e1a7c5-ad36-4c23-af19-337a54e45ee2)

We have fixed this for the site in question by setting the min and max entries field to 1, and it now behaves exactly the same as if the static field lightswitch was enabled.

This PR automates this process to help avoid anyone having to make any manual updates for future migrations to Craft 5, by overriding the min and max entries field if the static field lightswitch is enabled.

I have tested this update on the next site we are updating to Craft 5, and am very happy with the results.